### PR TITLE
Mobile filter interface

### DIFF
--- a/filter.css
+++ b/filter.css
@@ -30,6 +30,17 @@ body {
     transition: opacity 0.3s, visibility 0.3s;
 }
 
+@media screen and (max-width: 480px) {
+    .filter_box {
+        position: fixed;
+        top: -350px;
+        left: 1.5rem;
+        max-width: 320px;
+        z-index: 1000;
+        font-size: 1.4rem;
+    }
+}
+
 .filter_box_content {
     background-color: white;
     padding: 30px;
@@ -86,16 +97,11 @@ body {
     
 }
 
-
-
-
-
-
 /* Search Input */
 .search_input input {
     width: 50%;
     padding: 8px;
-    font-size: 1rem;
+    font-size: rem;
     border: 1px solid #ccc;
     border-radius: 5px;
 }

--- a/filter.css
+++ b/filter.css
@@ -37,7 +37,6 @@ body {
         left: 1.5rem;
         max-width: 320px;
         z-index: 1000;
-        font-size: 1.4rem;
     }
 }
 
@@ -101,7 +100,7 @@ body {
 .search_input input {
     width: 50%;
     padding: 8px;
-    font-size: rem;
+    font-size: 1rem;
     border: 1px solid #ccc;
     border-radius: 5px;
 }

--- a/filter.css
+++ b/filter.css
@@ -59,8 +59,8 @@ body {
 /* Close Button */
 .filter_box_close {
     position: absolute;
-    top: 10px;
-    right: 10px;
+    top: 5px;
+    right: 15px;
     font-size: 1.5rem;
     font-weight: bold;
     cursor: pointer;
@@ -81,6 +81,10 @@ body {
 .section {
     flex: 1 1 45%; 
     min-width: 200px; /* Prevent sections from getting too small */
+}
+
+#close_button {
+    font-size: 3rem;
 }
 
 .section h5 {


### PR DESCRIPTION
Process: Needs to apply some CSS in order for the current filter interface to act like a modal for mobile/small screen users. This should be possible to resolve by using CSS and media queries + position fixed.

Result: Result should be that a large part of the screen is covered by the modal like div. 

For now I choose to make it simple and let the flexbox decide the height with a maximum width for the filter_box.

Branchname: mobileFilterInterface